### PR TITLE
Batch transactions without tezos-client binary

### DIFF
--- a/goTest/goTest.go
+++ b/goTest/goTest.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+  "fmt"
+  "github.com/fkbenjamin/go-tezos"
+)
+
+//Please use another rpc for real money tx. This is just for testing purpose!
+var url = "https://rpc.tezrpc.me:443"
+
+//Used to show how to use added features to Create Batch Payments. The signed operations are not injeced but rather returned as an array.
+func main() {
+  goTezos.SetRPCURL(url);
+
+  var testPay goTezos.Payment
+  testPay.Address = "tz1fHyywxNwfEgxzCj95hCGXPdTTPtj2C5BA"
+  testPay.Amount = 1
+
+  var payments []goTezos.Payment
+  for i := 0; i < 100; i++ {
+    payments = append(payments, testPay)
+  }
+  dec_sigs := goTezos.CreateBatchPayment(payments)
+  fmt.Println(dec_sigs)
+}

--- a/goTezosOpertations.go
+++ b/goTezosOpertations.go
@@ -1,101 +1,47 @@
 package goTezos
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"log"
-	"os/exec"
+	"strconv"
+	"encoding/json"
+	"encoding/hex"
+	"math"
+
+	"github.com/jamesruan/sodium"
+  "github.com/tyler-smith/go-bip39"
+  "github.com/Messer4/base58check"
+  generichash "github.com/GoKillers/libsodium-go/cryptogenerichash"
+	encoding "github.com/anaskhan96/base58check"
 )
 
-//A function to get the signature for an operation. Not Tested. Needs rewrote to not depend on tezos-client binary.
-func GetSignatureForOp(tezosClientPath, opBytes, walletAlias string) (string, error) {
-	opBytes = "0x03" + opBytes
-	cmd := exec.Command(tezosClientPath, "sign", "bytes", opBytes, "for", walletAlias)
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		log.Fatal(err)
-	}
-	go func() {
-		defer stdin.Close()
+//How many Transactions per batch are injected. I recommend 100. Now 30 for easier testing
+var batchSize = 30
 
-		io.WriteString(stdin, "abcd1234")
-	}()
-	out1, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("%s\n", out1)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err = cmd.Run()
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Println("Result: " + out.String())
-	return out.String(), nil
-	// out, err := exec.Command(tezosClientPath, "sign", "bytes", opBytes, "for", "alias").Output()
-	// if err != nil {
-	// 	fmt.Println("Err in exec")
-	// 	return "", err
-	// }
-	// rtnStr, err := unMarshelString(out)
-	// if err != nil {
-	// 	return "", err
-	// }
-	// return rtnStr, nil
+//Forges batch payments and returns them ready to inject to an tezos rpc
+func CreateBatchPayment(payments []Payment)([]string) {
+	//Get current branch hash
+	branch_hash,_ := getBranchHash()
+	//import wallet or create a new one
+	wallet := createNewWallet()
+	//get the counter for the wallet && increment it
+	counter,_ := getAddressCounter(wallet.Address)
+	counter++
+	batches := splitPaymentIntoBatches(payments)
+	dec_sigs := make([]string, len(batches))
+	for k := range batches {
+    operation_bytes, _, newCounter := forgeOperationBytes(branch_hash, counter, wallet, batches[k])
+    counter = newCounter
+    signed_operation_bytes := signOperationBytes(operation_bytes, wallet)
+    //TODO: Here we could preapply, but eg. tezrpc is not supporting it
+    dec_sig := decodeSignature(signed_operation_bytes, operation_bytes)
+    dec_sigs[k] = dec_sig
+  }
+  return dec_sigs
 }
 
-//Takes an array of delegations and fills out the necessary structure to post to the tezos RPC to get the operation bytes to inject.
-// func ForgeMultiTransferOpertion(delegatedContracts []DelegatedContract, source string) (string, error) {
-// 	var contents Conts
-// 	var transOps []TransOp
-// 	strCounter, err := GetCounterForDelegate(source)
-// 	if err != nil {
-// 		return "", err
-// 	}
-// 	intCounter, err := strconv.Atoi(strCounter)
-// 	if err != nil {
-// 		return "", err
-// 	}
-
-// 	for _, contract := range delegatedContracts {
-// 		if contract.Address != source {
-// 			intCounter++
-// 			counter := strconv.Itoa(intCounter)
-// 			pay := strconv.FormatFloat(contract.TotalPayout, 'f', 6, 64)
-// 			i, err := strconv.ParseFloat(pay, 64)
-// 			if err != nil {
-// 				return "", errors.New("Could not get parse amount to payout: " + err.Error())
-// 			}
-// 			i = i * 1000000
-// 			if i != 0 {
-// 				transOps = append(transOps, TransOp{Kind: "transaction", Source: source, Fee: "0", GasLimit: "100", StorageLimit: "0", Amount: strconv.Itoa(int(i)), Destination: contract.Address, Counter: counter})
-// 			}
-
-// 		}
-// 	}
-// 	contents.Contents = transOps
-// 	contents.Branch = "BKs9YjNzRbhwtiqjkHFXGZ4jkCDBRRdMmm5DKZHQ6o8jH7imzZU"
-
-// 	forge := "/chains/main/blocks/head/helpers/forge/operations"
-// 	fmt.Println(PrettyReport(contents))
-
-// 	output, err := TezosRPCPost(forge, contents)
-// 	if err != nil {
-// 		return "", err
-// 	}
-// 	opBytes, err := unMarshelString(output)
-// 	if err != nil {
-// 		return "", err
-// 	}
-// 	return opBytes, nil
-// }
-
-//Gets the counter for a delegate, which is needed to forge an operation.
-func GetCounterForDelegate(phk string) (string, error) {
-	//8732/chains/main/blocks/head/context/contracts/tz1TP6gRyCSfgxauWwsbXi6s59MmvejcBAZa/counter
-	rpc := "/chains/main/blocks/head/context/contracts/" + phk + "/counter"
+func getBranchHash() (string, error) {
+	rpc := "/chains/main/blocks/head/hash"
 	resp, err := TezosRPCGet(rpc)
 	if err != nil {
 		return "", err
@@ -105,4 +51,148 @@ func GetCounterForDelegate(phk string) (string, error) {
 		return "", err
 	}
 	return rtnStr, nil
+}
+
+func createNewWallet()(Wallet){
+	//Could create a new wallet, but this misses the reveal tx...Just left this here for anyone curious.
+  //entropy, _ := bip39.NewEntropy(256)
+  //mnemonic, _ := bip39.NewMnemonic(entropy)
+
+	//WARNING!!! This is a random, empty mnemonic, DO NOT USE THIS!!!
+  mnemonic := "pipe drift dolphin tell install radio cave pool away mesh develop viable local hurt slow"
+  password := ""
+  seed := bip39.NewSeed(mnemonic, password)
+  var signSecretKey sodium.SignSecretKey
+  bytes_signSecretKey := []byte(seed)
+  signSecretKey.Bytes = bytes_signSecretKey
+  signSeed := signSecretKey.Seed()
+  signKP := sodium.SeedSignKP(signSeed)
+  key := sodium.GenericHashKey{signKP.PublicKey.Bytes}
+  genericHash, _ := generichash.CryptoGenericHash(20, key.Bytes, nil)
+
+	//Prefixes needed to get the right format
+  tz1 := []byte{6,161,159}
+  edsk := []byte{43, 246, 78, 7}
+  edpk := []byte{13, 15, 37, 217}
+
+  var wallet Wallet
+  wallet.Address = b58cencode(genericHash, tz1)
+  wallet.Mnemonic = mnemonic
+  wallet.Seed = seed
+  wallet.Kp = signKP
+  wallet.Sk =  b58cencode(signKP.SecretKey.Bytes, edsk)
+  wallet.Pk =  b58cencode(signKP.PublicKey.Bytes, edpk)
+  return wallet
+}
+
+//Getting the Counter of an address from the RPC
+func getAddressCounter(address string)(int, error) {
+	rpc := "/chains/main/blocks/head/context/contracts/" + address + "/counter"
+	resp, err := TezosRPCGet(rpc)
+	if err != nil {
+		return 0, err
+	}
+	rtnStr, err := unMarshelString(resp)
+	if err != nil {
+		return 0, err
+	}
+	counter, err := strconv.Atoi(rtnStr)
+  return counter, err
+}
+
+func splitPaymentIntoBatches(rewards []Payment) ([][]Payment){
+  var batches [][]Payment
+  for i := 0; i < len(rewards); i += batchSize {
+    end := i + batchSize
+    if end > len(rewards) {
+        end = len(rewards)
+    }
+    batches = append(batches, rewards[i:end])
+  }
+  return batches
+}
+
+func forgeOperationBytes(branch_hash string, counter int, wallet Wallet, batch []Payment)(string, Conts, int) {
+  var contents Conts
+  var combinedOps []TransOp
+  //left here to display how to reveal a new wallet (needs funds to be revealed!)
+  /**
+    combinedOps = append(combinedOps, TransOp{Kind: "reveal", PublicKey: wallet.pk , Source: wallet.address, Fee: "0", GasLimit: "127", StorageLimit: "0", Counter: strCounter})
+    counter++
+  **/
+  for k := range batch {
+    if batch[k].Amount > 0 {
+      operation := TransOp{Kind: "transaction", Source: wallet.Address, Fee: "1420", GasLimit: "11000", StorageLimit: "0", Amount: strconv.FormatFloat(roundPlus(batch[k].Amount, 0), 'f', -1, 64), Destination: batch[k].Address , Counter: strconv.Itoa(counter)}
+  		combinedOps = append(combinedOps, operation)
+      counter++
+    }
+  }
+  contents.Contents = combinedOps
+  contents.Branch = branch_hash
+  var opBytes string
+
+  forge := "/chains/main/blocks/head/helpers/forge/operations"
+  output, err := TezosRPCPost(forge, contents)
+  if err != nil {
+     return "", contents, counter
+    }
+  err = json.Unmarshal(output, &opBytes)
+  if err != nil {
+    log.Println("Could not unmarshel to string " + err.Error())
+    return "", contents, counter
+  }
+  return opBytes, contents, counter
+}
+
+//Sign previously forged Operation bytes using secret key of wallet
+func signOperationBytes(operation_bytes string, wallet Wallet)(string){
+	//Prefixes
+  edsigByte := []byte{9, 245, 205, 134, 18}
+  watermark := []byte{3}
+
+  op, err := hex.DecodeString(operation_bytes)
+	if err != nil {
+		log.Fatal(err)
+	}
+  op = append(watermark, op...)
+  genericHash, _ := generichash.CryptoGenericHash(32, op, nil)
+  sig := sodium.Bytes(genericHash).SignDetached(wallet.Kp.SecretKey)
+  edsig := b58cencode(sig.Bytes, edsigByte)
+  return edsig
+}
+
+func decodeSignature(sig string, operation_bytes string)(dec_sig string){
+  dec_bytes, err := encoding.Decode(sig)
+	if err != nil {
+		fmt.Println(err.Error())
+		return ""
+	}
+  dec_sig = string(dec_bytes)
+  //no need to cut the 8 last hexbyte, that's already done
+  dec_sig = dec_sig[10:(len(dec_sig))]
+  dec_sig = operation_bytes +  dec_sig
+  return
+}
+
+//Helper Function to get the right format for wallet.
+func b58cencode (payload []byte, prefix []byte)(string) {
+  n := make([]byte, (len(prefix) + len(payload)))
+  for k := range prefix {
+    n[k] = prefix[k]
+  }
+  for l := range payload {
+    n[l + len(prefix)] = payload[l]
+  }
+  b58c := base58check.Encode(n)
+  return b58c
+}
+
+//Helper Functions to round float64
+func roundPlus(f float64, places int) (float64) {
+    shift := math.Pow(10, float64(places))
+    return round(f * shift) / shift;
+}
+
+func round(f float64) float64 {
+    return math.Floor(f + .5)
 }

--- a/goTezosStructs.go
+++ b/goTezosStructs.go
@@ -5,6 +5,8 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"log"
 	"time"
+
+	"github.com/jamesruan/sodium"
 )
 
 //An unmarsheled representation of a block returned by the Tezos RPC API.
@@ -354,4 +356,20 @@ type BCycles struct {
 type ECycles struct {
 	Cycle           int              `json: "cycle"`
 	EndorsingRights Endorsing_Rights `json: "endorsing_rights"`
+}
+
+//Wallet needed for signing operations
+type Wallet struct {
+  Address string
+  Mnemonic string
+  Seed []byte
+  Kp sodium.SignKP
+  Sk string
+  Pk string
+}
+
+//Struct used to define transactions in a batch operation.
+type Payment struct {
+	Address string
+	Amount float64
 }


### PR DESCRIPTION
I rewrote goTezosOpertations.go so that you can create batch operations without the need for the tezos-client binary. All it requires is the link to a working rpc and sodium installed locally installed. goTest/goTest.go shows how to use the changes to create signed bytes for batch operations. If you have any questions/issues with the code or require some changes, let me know.

PS: Sorry that it took so long, I had too much going on to implement this in the repo.