### PR TITLE
Discover which network client is connected

### DIFF
--- a/goTezos.go
+++ b/goTezos.go
@@ -44,6 +44,33 @@ func (this *GoTezos) AddNewClient(client *TezosRPCClient) {
 		fmt.Println("Could not get network constants, library will fail. Exiting .... ")
 		os.Exit(0)
 	}
+	
+	this.Versions, err = this.GetNetworkVersions()
+	if err != nil {
+		fmt.Println("Could not get network version, library will fail. Exiting .... ")
+		os.Exit(0)
+	}
+}
+
+func (this *GoTezos) IsMainnet() bool {
+	if len(this.Versions) > 0 {
+		return this.Versions[0].Network == "BETANET"
+	}
+	return false
+}
+
+func (this *GoTezos) IsAlphanet() bool {
+	if len(this.Versions) > 0 {
+		return this.Versions[0].Network == "ALPHANET"
+	}
+	return false
+}
+
+func (this *GoTezos) IsZeronet() bool {
+	if len(this.Versions) > 0 {
+		return this.Versions[0].Network == "ZERONET"
+	}
+	return false
 }
 
 func (this *GoTezos) UseBalancerStrategyFailover() {

--- a/goTezosBlock.go
+++ b/goTezosBlock.go
@@ -363,17 +363,3 @@ func (this *GoTezos) GetChainId() (string, error) {
 
 	return chainId, nil
 }
-
-//Gets the branch hash
-func (this *GoTezos) getBranchHash() (string, error) {
-	rpc := "/chains/main/blocks/head/hash"
-	resp, err := this.GetResponse(rpc, "{}")
-	if err != nil {
-		return "", err
-	}
-	rtnStr, err := unMarshalString(resp.Bytes)
-	if err != nil {
-		return "", err
-	}
-	return rtnStr, nil
-}

--- a/goTezosBlock.go
+++ b/goTezosBlock.go
@@ -110,6 +110,37 @@ func (this *GoTezos) GetNetworkConstants() (NetworkConstants, error) {
 	return networkConstants, nil
 }
 
+func (this *GoTezos) GetNetworkVersions() ([]NetworkVersion, error) {
+	
+	networkVersions := make([]NetworkVersion, 0)
+	
+	resp, err := this.GetResponse("/network/versions", "{}")
+	if err != nil {
+		this.logger.Println("Could not get /network/versions: " + err.Error())
+		return networkVersions, err
+	}
+	
+	nvs, err := unMarshalNetworkVersion(resp.Bytes)
+	if err != nil {
+		this.logger.Println("Could not get network version: " + err.Error())
+		return networkVersions, err
+	}
+		
+	// Extract just the network name and append to returning slice
+	// 'range' operates on a copy of the struct so cannot update-in-place
+	for _, v := range nvs {
+		
+		parts := strings.Split(v.Name, "_")
+		if len(parts) == 3 {
+			v.Network = parts[1]
+		}
+		
+		networkVersions = append(networkVersions, v)
+	}
+	
+	return networkVersions, nil
+}
+
 func (this *GoTezos) GetBranchProtocol() (string, error) {
 	block, err := this.GetChainHead()
 	if err != nil {

--- a/goTezosStructs.go
+++ b/goTezosStructs.go
@@ -16,6 +16,24 @@ type ResponseRaw struct {
 	Bytes []byte
 }
 
+type NetworkVersion struct {
+	Name	string	`json:"name"`
+	Major	int		`json:"major"`
+	Minor	int		`json:"minor"`
+	Network	string	// Human readable network name
+}
+
+// unMarshals the bytes received as a parameter, into the type NetworkVersion.
+func unMarshalNetworkVersion(v []byte) ([]NetworkVersion, error) {
+	var nv []NetworkVersion
+	err := json.Unmarshal(v, &nv)
+	if err != nil {
+		log.Println("Could not get unMarshal bytes into NetworkVersion: " + err.Error())
+		return nv, err
+	}
+	return nv, nil
+}
+
 type NetworkConstants struct {
 	ProofOfWorkNonceSize         int      `json:"proof_of_work_nonce_size"`
 	NonceLength                  int      `json:"nonce_length"`
@@ -442,6 +460,7 @@ type GoTezos struct {
 	RpcClients       []*TezClientWrapper
 	ActiveRPCCient   *TezClientWrapper
 	Constants        NetworkConstants
+	Versions         []NetworkVersion
 	balancerStrategy string
 	rand             *rand.Rand
 	logger           *log.Logger


### PR DESCRIPTION
Added query of /network/versions and associated helper functions for determining if connected to mainnet, alphanet, or zeronet. Yes, "mainnet" still reports string as "betanet". When protocol of this is fixed, we can push a change.