### PR TITLE
Parse generic errors from RPC

### DIFF
--- a/goTezos.go
+++ b/goTezos.go
@@ -169,8 +169,6 @@ func (this *GoTezos) HandleResponse(method string, path string, args string) (Re
 	if err != nil {
 		this.ActiveRPCCient.healthy = false
 		this.logger.Println(this.ActiveRPCCient.client.Host+this.ActiveRPCCient.client.Port, "Client state switched to unhealthy")
-		
-		// TODO: this recursive call has no limit protection
 		return this.GetResponse(path, args)
 	}
 	

--- a/goTezos.go
+++ b/goTezos.go
@@ -184,9 +184,7 @@ func (this *GoTezos) HandleResponse(method string, path string, args string) (Re
 		
 		// Just return the first error for now
 		// TODO: Return all errors
-		e := rpcErrors.Errors[0]
-		
-		return r, fmt.Errorf("RPC Error (%s): %s", e.Kind, e.Error)
+		return r, fmt.Errorf("RPC Error (%s): %s", rpcErrors[0].Kind, rpcErrors[0].Error)
 	}
 	
 	return r, err

--- a/goTezosBlock.go
+++ b/goTezosBlock.go
@@ -55,7 +55,7 @@ func (this *GoTezos) GetSnapShot(cycle int) (SnapShot, error) {
 		snap.AssociatedBlock = 1
 	}
 	snap.AssociatedHash, _ = this.GetBlockHashAtLevel(snap.AssociatedBlock)
-		
+
 	return snap, nil
 }
 
@@ -90,6 +90,7 @@ func (this *GoTezos) GetChainHead() (Block, error) {
 		this.logger.Println("Could not get block head: " + err.Error())
 		return block, err
 	}
+
 	return block, nil
 }
 

--- a/goTezosBlock.go
+++ b/goTezosBlock.go
@@ -6,18 +6,12 @@ import (
 	"strings"
 )
 
-
 //Takes a cycle number and returns a helper structure describing a snap shot on the tezos network.
 func (this *GoTezos) GetSnapShot(cycle int) (SnapShot, error) {
 	
 	var snapShotQuery SnapShotQuery
 	var snap SnapShot
 	var get string
-	
-	// Check cache first
-	if cachedSS, exists := snapshotCache[cycle]; exists {
-		return cachedSS, nil
-	}
 	
 	currentCycle, err := this.GetCurrentCycle()
 	if err != nil {
@@ -61,13 +55,7 @@ func (this *GoTezos) GetSnapShot(cycle int) (SnapShot, error) {
 		snap.AssociatedBlock = 1
 	}
 	snap.AssociatedHash, _ = this.GetBlockHashAtLevel(snap.AssociatedBlock)
-	
-	// Cache for future
-	if snapshotCache == nil {
-		snapshotCache = make(map[int]SnapShot)
-	}
-	snapshotCache[cycle] = snap
-	
+		
 	return snap, nil
 }
 

--- a/goTezosBlock.go
+++ b/goTezosBlock.go
@@ -357,17 +357,3 @@ func (this *GoTezos) GetChainId() (string, error) {
 
 	return chainId, nil
 }
-
-//Gets the branch hash
-func (this *GoTezos) getBranchHash() (string, error) {
-	rpc := "/chains/main/blocks/head/hash"
-	resp, err := this.GetResponse(rpc, "{}")
-	if err != nil {
-		return "", err
-	}
-	rtnStr, err := unMarshalString(resp.Bytes)
-	if err != nil {
-		return "", err
-	}
-	return rtnStr, nil
-}

--- a/goTezosBlock.go
+++ b/goTezosBlock.go
@@ -6,10 +6,6 @@ import (
 	"strings"
 )
 
-var (
-	chainHeadCache Block
-	snapshotCache  map[int]SnapShot
-)
 
 //Takes a cycle number and returns a helper structure describing a snap shot on the tezos network.
 func (this *GoTezos) GetSnapShot(cycle int) (SnapShot, error) {

--- a/goTezosBlock.go
+++ b/goTezosBlock.go
@@ -79,28 +79,18 @@ func (this *GoTezos) GetAllCurrentSnapShots() ([]SnapShot, error) {
 
 //Returns the head block from the Tezos RPC.
 func (this *GoTezos) GetChainHead() (Block, error) {
-	
-	// Check cache
-	if chainHeadCache.Hash == "" {
-		
-		var block Block
-		
-		resp, err := this.GetResponse("/chains/main/blocks/head", "{}")
-		if err != nil {
-			this.logger.Println("Could not get /chains/main/blocks/head: " + err.Error())
-			return block, err
-		}
-		
-		block, err = unMarshalBlock(resp.Bytes)
-		if err != nil {
-			this.logger.Println("Could not get block head: " + err.Error())
-			return block, err
-		}
-	
-		chainHeadCache = block
+	var block Block
+	resp, err := this.GetResponse("/chains/main/blocks/head", "{}")
+	if err != nil {
+		this.logger.Println("Could not get /chains/main/blocks/head: " + err.Error())
+		return block, err
 	}
-			
-	return chainHeadCache, nil
+	block, err = unMarshalBlock(resp.Bytes)
+	if err != nil {
+		this.logger.Println("Could not get block head: " + err.Error())
+		return block, err
+	}
+	return block, nil
 }
 
 func (this *GoTezos) GetNetworkConstants() (NetworkConstants, error) {

--- a/goTezosStructs.go
+++ b/goTezosStructs.go
@@ -450,18 +450,14 @@ type GoTezos struct {
 
 
 // Generic error from RPC. Returns an array/slice of error objects
-type RPCGenericErrors struct {
-	Errors	[]RPCGenericError
-}
-
 type RPCGenericError struct {
 	Kind	string	`json:"kind"`
 	Error	string	`json:"error"`
 }
 
-func unMarshalRPCGenericErrors(v []byte) (RPCGenericErrors, error) {
+func unMarshalRPCGenericErrors(v []byte) ([]RPCGenericError, error) {
 	
-	var r RPCGenericErrors
+	var r []RPCGenericError
 
 	err := json.Unmarshal(v, &r)
 	if err != nil {

--- a/goTezosStructs.go
+++ b/goTezosStructs.go
@@ -447,3 +447,26 @@ type GoTezos struct {
 	logger           *log.Logger
 	debug            bool
 }
+
+
+// Generic error from RPC. Returns an array/slice of error objects
+type RPCGenericErrors struct {
+	Errors	[]RPCGenericError
+}
+
+type RPCGenericError struct {
+	Kind	string	`json:"kind"`
+	Error	string	`json:"error"`
+}
+
+func unMarshalRPCGenericErrors(v []byte) (RPCGenericErrors, error) {
+	
+	var r RPCGenericErrors
+
+	err := json.Unmarshal(v, &r)
+	if err != nil {
+		return r, err
+	}
+	
+	return r, nil
+}


### PR DESCRIPTION
This PR adds generic error struct parsing. I encountered this when I was trying to push lots of batch payments. Figured catching/parsing the JSON presents a better experience.
Also removed a duplicate func `getBranchHash()`. There's also GetBranchHash() which is used throughout the library. The former (lowercase) is not used anywhere.