### PR TITLE
Add parsing of block operations

### DIFF
--- a/goTezosBlock.go
+++ b/goTezosBlock.go
@@ -189,14 +189,8 @@ func (this *GoTezos) GetBlockByHash(hash string) (Block, error) {
 //Returns list of operations in block of head
 func (this *GoTezos) GetBlockOperationHashesHead() (OperationHashes, error) {
 	
-	var operations OperationHashes
-	
-	headLevel, _, err := this.GetBlockLevelHead()
-	if err != nil {
-		return operations, err
-	}
-	
-	return this.GetBlockOperationHashesAtLevel(headLevel)
+	// head~0 == head
+	return this.GetBlockOperationHashesAtLevel(0)
 }
 
 //Returns list of operations in block at specific level

--- a/goTezosBlock.go
+++ b/goTezosBlock.go
@@ -186,6 +186,45 @@ func (this *GoTezos) GetBlockByHash(hash string) (Block, error) {
 	return block, nil
 }
 
+//Returns list of operations in block of head
+func (this *GoTezos) GetBlockOperationHashesHead() (OperationHashes, error) {
+	
+	var operations OperationHashes
+	
+	headLevel, _, err := this.GetBlockLevelHead()
+	if err != nil {
+		return operations, err
+	}
+	
+	return this.GetBlockOperationHashesAtLevel(headLevel)
+}
+
+//Returns list of operations in block at specific level
+func (this *GoTezos) GetBlockOperationHashesAtLevel(level int) (OperationHashes, error) {
+	
+	var operations OperationHashes
+	
+	blockHash, err := this.GetBlockHashAtLevel(level)
+	if err != nil {
+		this.logger.Printf("Could not get block hash at level %d: %s\n", level, err)
+		return operations, err
+	}
+	
+	resp, err := this.GetResponse("/chains/main/blocks/" + blockHash + "/operation_hashes", "{}")
+	if err != nil {
+		this.logger.Println("Could not get block operation_hashes: " + err.Error())
+		return operations, err
+	}
+	
+	operations, err = unMarshalOperationHashes(resp.Bytes)
+	if err != nil {
+		this.logger.Println("Could not decode operation hashes: " + err.Error())
+		return operations, err
+	}
+	
+	return operations, nil
+}
+
 //Gets the balance of a public key hash at a specific snapshot for a cycle.
 func (this *GoTezos) GetAccountBalanceAtSnapshot(tezosAddr string, cycle int) (float64, error) {
 	snapShot, err := this.GetSnapShot(cycle)

--- a/goTezosStructs.go
+++ b/goTezosStructs.go
@@ -447,3 +447,29 @@ type GoTezos struct {
 	logger           *log.Logger
 	debug            bool
 }
+
+// Operation hashes slice
+type OperationHashes []string
+
+func unMarshalOperationHashes(v []byte) (OperationHashes, error) {
+	
+	// RPC returns slice of slice
+	// Will flatten to single slice of ops for easy use
+	
+	var ops [][]string
+	var opHashes OperationHashes
+	
+	err := json.Unmarshal(v, &ops)
+	if err != nil {
+		return opHashes, err
+	}
+	
+	// flatten
+	for _, i := range ops {
+		for _, j := range i {
+			opHashes = append(opHashes, j)
+		}
+	}
+	
+	return opHashes, nil
+}


### PR DESCRIPTION
After POSTing an operation to RPC, this PR allows clients to query head block or specific level block looking for that operation's hash. Allows for verification that their op did make it to the chain.