### PR TITLE
Add balance to returned share calculation

### DIFF
--- a/goTezosStructs.go
+++ b/goTezosStructs.go
@@ -382,6 +382,7 @@ type ContractRewards struct {
 	DelegationPhk string  `json:"delegation"`
 	Share         float64 `json:"share"`
 	GrossRewards  string  `json:"rewards"`
+	Balance       float64 `json:"balance"`
 }
 
 //A structure representing baking rights for a specific delegate between cycles


### PR DESCRIPTION
When you call GetRewardsForDelegateCycle(), the resulting DelegationServiceRewards->..ContractRewards does not contain the delegates original balance on which their % share is calculated. This PR simply adds this information into the returning ContractRewards struct. This information is being used for display/reporting purposes when printing out cycle rewards report.