### PR TITLE
Quick fix for finding block operations

### DIFF
--- a/goTezos.go
+++ b/goTezos.go
@@ -207,7 +207,7 @@ func (this *GoTezos) HandleResponse(method string, path string, args string) (Re
 	}
 	
 	// Received a HTTP 200 OK response, but payload could contain error message
-	if strings.Contains(string(r.Bytes), "error") {
+	if strings.Contains(string(r.Bytes), "\"error\":") {
 		
 		rpcErrors, err := unMarshalRPCGenericErrors(r.Bytes)
 		if err != nil {

--- a/goTezosBlock.go
+++ b/goTezosBlock.go
@@ -236,7 +236,10 @@ func (this *GoTezos) GetBlockAtLevel(level int) (Block, error) {
 	
 	diffStr := strconv.Itoa(headLevel - level)
 	getBlockByLevel := "/chains/main/blocks/" + headHash + "~" + diffStr
-	fmt.Println(getBlockByLevel)
+	
+	if this.debug {
+		this.logger.Printf("DEBUG: - %s\n", getBlockByLevel)
+	}
 
 	resp, err := this.GetResponse(getBlockByLevel, "{}")
 	if err != nil {


### PR DESCRIPTION
* Fix for calling `GetBlockOperationHashesHead()` which always returned the genesis block.
* Fix for checking generic errors since the word "error" may show up in normal blocks metadata