### PR TITLE
Fix snapshot calculation

### DIFF
--- a/goTezosBlock.go
+++ b/goTezosBlock.go
@@ -64,7 +64,7 @@ func (this *GoTezos) GetSnapShot(cycle int) (SnapShot, error) {
 
 	snap.Number = snapShotQuery.RollSnapShot
 
-	snap.AssociatedBlock = ((cycle - this.Constants.PreservedCycles) * this.Constants.BlocksPerCycle) + (snapShotQuery.RollSnapShot+1)*256
+	snap.AssociatedBlock = ((cycle - this.Constants.PreservedCycles - 2) * this.Constants.BlocksPerCycle) + (snapShotQuery.RollSnapShot+1)*256
 	if snap.AssociatedBlock < 1 {
 		snap.AssociatedBlock = 1
 	}


### PR DESCRIPTION
Interestingly, everything still works fine, even though the calculation is off. I wonder if this would have more impact on a node that has ran `tezos-node` garbage collection.

Test script. Just change the RPC pointer from localhost (my alphanet node) to a mainnet node.

```
package main

import (
	"fmt"
	"log"
	"os"
	
	goTezos "github.com/DefinitelyNotAGoat/go-tezos"	
)

func main() {
	
	gtClient := goTezos.NewTezosRPCClient("localhost", "8732")
	
	gt := goTezos.NewGoTezos()
	gt.AddNewClient(gtClient)
	
	sss, _ := gt.GetAllCurrentSnapShots()
	for _, i := range sss {
		fmt.Println("Cycle:", i.Cycle, "- Number:", i.Number, "- Block:", i.AssociatedBlock)
	}

}
```