### PR TITLE
Remove some unnecessary block fetches

### DIFF
--- a/account.go
+++ b/account.go
@@ -55,12 +55,7 @@ func (s *AccountService) GetBalanceAtSnapshot(tezosAddr string, cycle int) (floa
 		return 0, fmt.Errorf("could not get %s balance for snap shot at %d cycle: %v", tezosAddr, cycle, err)
 	}
 
-	block, err := s.gt.Block.Get(snapShot.AssociatedBlock)
-	if err != nil {
-		return 0, fmt.Errorf("could not get %s balance for snap shot at %d cycle: %v", tezosAddr, cycle, err)
-	}
-
-	query := "/chains/main/blocks/" + block.Hash + "/context/contracts/" + tezosAddr + "/balance"
+	query := "/chains/main/blocks/" + snapShot.AssociatedHash + "/context/contracts/" + tezosAddr + "/balance"
 	resp, err := s.gt.Get(query, nil)
 	if err != nil {
 		return 0, fmt.Errorf("could not get %s balance for snap shot at %d cycle: %v", tezosAddr, cycle, err)

--- a/snapshots.go
+++ b/snapshots.go
@@ -50,12 +50,8 @@ func (s *SnapShotService) Get(cycle int) (SnapShot, error) {
 
 	query := "/chains/main/blocks/"
 	if cycle < currentCycle {
-		block, err := s.gt.Block.Get(cycle*s.gt.Constants.BlocksPerCycle + 1)
-		if err != nil {
-			return snap, fmt.Errorf("could not get snapshot %d: %v", cycle, err)
-		}
-		query = query + block.Hash + "/context/raw/json/cycle/" + strCycle
-
+		block := strconv.Itoa(cycle*s.gt.Constants.BlocksPerCycle + 1)
+		query = query + block + "/context/raw/json/cycle/" + strCycle
 	} else {
 		query = query + "head/context/raw/json/cycle/" + strCycle
 	}


### PR DESCRIPTION
Optimize `AccountService.GetBalanceAtSnapshot` and `SnapShotService.Get` by removing unnecessary block fetches.