### PR TITLE
fix bug with HTTPS RPC endpoint for node URL not being recognized

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,7 +22,7 @@ func newClient(URL string) *client {
 	if URL[len(URL)-1] == '/' {
 		URL = URL[:len(URL)-1]
 	}
-	if URL[0:7] != "http://" && URL[0:7] != "https://" {
+	if URL[0:7] != "http://" && URL[0:8] != "https://" {
 		URL = fmt.Sprintf("http://%s", URL)
 	}
 


### PR DESCRIPTION
RPC node endpoints using HTTPS (for example `https://myrpc.com`) are being prepended with the string `http://`, resulting in RPC requests getting sent to, for example, `http://https//alphanet.tezrpc.me`.

This PR resolves the bug by simply properly checking for the existence of the string `https://` in the node endpoint.