### PR TITLE
Add Cycle in addition to Level in StructBalanceUpdates

### DIFF
--- a/block.go
+++ b/block.go
@@ -85,6 +85,7 @@ type StructBalanceUpdates struct {
 	Change   string `json:"change"`
 	Category string `json:"category,omitempty"`
 	Delegate string `json:"delegate,omitempty"`
+	Cycle    int    `json:"cycle,omitempty"`
 	Level    int    `json:"level,omitempty"`
 }
 


### PR DESCRIPTION
`Cycle` replaces `Level` in Protocol 4, but alphanet and zeronet appear to still be running Protocol 3 so keep this for backwards compatibility.