### PR TITLE
Improvements to getDelegationReports performance

### DIFF
--- a/account.go
+++ b/account.go
@@ -73,6 +73,27 @@ func (s *AccountService) GetBalanceAtSnapshot(tezosAddr string, cycle int) (floa
 	return floatBalance / MUTEZ, nil
 }
 
+// GetBalanceAtAssociatedSnapshotBlock gets the balance of a contract at a associated snapshot block.
+func (s *AccountService) GetBalanceAtAssociatedSnapshotBlock(tezosAddr string, associatedBlockHash string) (float64, error) {
+	query := "/chains/main/blocks/" + associatedBlockHash + "/context/contracts/" + tezosAddr + "/balance"
+	resp, err := s.gt.Get(query, nil)
+	if err != nil {
+		return 0, errors.Errorf("could not get %s balance for snap shot at %s block: %v", tezosAddr, associatedBlockHash, err)
+	}
+
+	strBalance, err := unmarshalString(resp)
+	if err != nil {
+		return 0, errors.Errorf("could not get %s balance for snap shot at %s block: %v", tezosAddr, associatedBlockHash, err)
+	}
+
+	floatBalance, err := strconv.ParseFloat(strBalance, 64)
+	if err != nil {
+		return 0, errors.Errorf("could not get %s balance for snap shot at %s block: %v", tezosAddr, associatedBlockHash, err)
+	}
+
+	return floatBalance / MUTEZ, nil
+}
+
 // GetBalance gets the balance of a public key hash at a specific snapshot for a cycle.
 func (s *AccountService) GetBalance(tezosAddr string) (float64, error) {
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/DefinitelyNotAGoat/go-tezos
+module github.com/romarq/go-tezos
 
 go 1.12
 

--- a/gotezos_test.go
+++ b/gotezos_test.go
@@ -336,6 +336,21 @@ func TestDelegateGetReport(t *testing.T) {
 
 }
 
+func TestDelegateGetReportWithoutDelegations(t *testing.T) {
+	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	if err != nil {
+		t.Errorf("could not connect to network")
+	}
+
+	report, err := gt.Delegate.GetReportWithoutDelegations("tz1T8UYSbVuRm6CdhjvwCfXsKXb4yL9ai9Q3", 172)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	t.Log(PrettyReport(report))
+
+}
+
 func TestGetPayments(t *testing.T) {
 	gt, err := NewGoTezos("http://127.0.0.1:8732")
 	if err != nil {

--- a/gotezos_test.go
+++ b/gotezos_test.go
@@ -236,6 +236,18 @@ func TestGetAccountBalanceAtSnapshot(t *testing.T) {
 	}
 }
 
+func TestGetAccountBalanceAtAssociatedSnapshotBlock(t *testing.T) {
+	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	if err != nil {
+		t.Errorf("could not connect to network")
+	}
+
+	_, err = gt.Account.GetBalanceAtAssociatedSnapshotBlock("tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB", "head")
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+}
+
 func TestGetAccountBalance(t *testing.T) {
 	gt, err := NewGoTezos("http://127.0.0.1:8732")
 	if err != nil {

--- a/snapshots.go
+++ b/snapshots.go
@@ -69,7 +69,7 @@ func (s *SnapShotService) Get(cycle int) (SnapShot, error) {
 
 	snap.Number = snapShotQuery.RollSnapShot
 
-	snap.AssociatedBlock = ((cycle - s.gt.Constants.PreservedCycles - 2) * s.gt.Constants.BlocksPerCycle) + (snapShotQuery.RollSnapShot+1)*256
+	snap.AssociatedBlock = ((cycle - s.gt.Constants.PreservedCycles - 2) * s.gt.Constants.BlocksPerCycle) + (snap.Number+1)*s.gt.Constants.BlocksPerRollSnapshot
 	if snap.AssociatedBlock < 1 {
 		snap.AssociatedBlock = 1
 	}


### PR DESCRIPTION
Improved **getDelegationReports** performance, removed redundant requests that were heavily impacting the performance for delegates with big amounts of delegators.

Now it also creates channels based on the number of delegators #72 

Requests are much faster now.

A request to a delegate with 1032 delegators:
Time: **8.02s**
Size: **147KB**

Before It could not even complete the request and resulted in Timeout.