### PR TITLE
Added support for environment variables and changed tests to be more abstract

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+RPC_ADDRESS=http://rpc.tezaria.com

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,7 @@ go 1.12
 
 require (
 	github.com/Messer4/base58check v0.0.0-20180328134002-7531a92ae9ba
+	github.com/joho/godotenv v1.3.0
+	github.com/pkg/errors v0.8.1
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/Messer4/base58check v0.0.0-20180328134002-7531a92ae9ba h1:e0baDNoruF8YR/JRUmljBoQwxWSOL8MXPFPxWN0GOXk=
 github.com/Messer4/base58check v0.0.0-20180328134002-7531a92ae9ba/go.mod h1:NtsVEFPEMr0LH6B51gU0o+JYyiIb+jKEa49+t9tMbtM=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/LemDnOc1GiZL5FCVlORJ5zo=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/gotezos.go
+++ b/gotezos.go
@@ -3,8 +3,10 @@ package gotezos
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 	"strings"
 
+	"github.com/joho/godotenv"
 	"github.com/pkg/errors"
 )
 
@@ -42,8 +44,22 @@ type genericRPCError struct {
 type genericRPCErrors []genericRPCError
 
 // NewGoTezos is a constructor that returns a GoTezos object
-func NewGoTezos(URL string) (*GoTezos, error) {
+func NewGoTezos(URL ...string) (*GoTezos, error) {
 	gt := GoTezos{}
+
+	var url string
+	if len(URL) > 1 {
+		// RPC Address
+		url = URL[0]
+	} else {
+		err := godotenv.Load()
+		if err != nil {
+			return &gt, errors.Wrap(err, "Error loading .env file")
+		}
+
+		url = os.Getenv("RPC_ADDRESS")
+	}
+
 	gt.Block = gt.newBlockService()
 	gt.SnapShot = gt.newSnapShotService()
 	gt.Cycle = gt.newCycleService()
@@ -54,7 +70,7 @@ func NewGoTezos(URL string) (*GoTezos, error) {
 	gt.Contract = gt.newContractService()
 	gt.Node = gt.newNodeService()
 
-	gt.client = newClient(URL)
+	gt.client = newClient(url)
 
 	var err error
 	gt.Constants, err = gt.Network.GetConstants()

--- a/gotezos_test.go
+++ b/gotezos_test.go
@@ -24,7 +24,7 @@ func TestCreateWalletWithMnemonic(t *testing.T) {
 		},
 	}
 
-	gt, _ := NewGoTezos("http://127.0.0.1:8732")
+	gt, _ := NewGoTezos()
 
 	for _, c := range cases {
 		myWallet, err := gt.Account.CreateWallet(c.mnemonic, c.email+c.password)
@@ -54,7 +54,7 @@ func TestImportWalletFullSk(t *testing.T) {
 		},
 	}
 
-	gt, _ := NewGoTezos("http://127.0.0.1:8732")
+	gt, _ := NewGoTezos()
 
 	for _, c := range cases {
 		myWallet, err := gt.Account.ImportWallet(c.pkh, c.pk, c.sk)
@@ -86,7 +86,7 @@ func TestImportWalletSeedSk(t *testing.T) {
 		},
 	}
 
-	gt, _ := NewGoTezos("http://127.0.0.1:8732")
+	gt, _ := NewGoTezos()
 
 	for _, c := range cases {
 		myWallet, err := gt.Account.ImportWallet(c.pkh, c.pk, c.sks)
@@ -118,7 +118,7 @@ func TestImportEncryptedSecret(t *testing.T) {
 		},
 	}
 
-	gt, _ := NewGoTezos("http://127.0.0.1:8732")
+	gt, _ := NewGoTezos()
 
 	for _, c := range cases {
 
@@ -133,32 +133,22 @@ func TestImportEncryptedSecret(t *testing.T) {
 	}
 }
 func TestGetSnapShot(t *testing.T) {
-	var cases = []struct {
-		in  int
-		out SnapShot
-	}{
-		{171, SnapShot{Cycle: 171, AssociatedBlock: 340992, AssociatedHash: "BLV6XGmLgvkNi7BgCCbLjD3mdQ3LaZQCLcZa6aFzPsDuu3ySQvU"}},
-		{132, SnapShot{Cycle: 132, AssociatedBlock: 261376, AssociatedHash: "BMUaWotqn6icj8Wk1ERJJLGVvdLMc75fUrPkG7dLhAMYFcWBYfe"}},
-	}
-
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	for _, c := range cases {
-		snapshot, err := gt.SnapShot.Get(c.in)
-		if err != nil {
-			t.Error(err)
-		}
-		if c.out.AssociatedBlock != snapshot.AssociatedBlock || c.out.AssociatedHash != snapshot.AssociatedHash || c.out.Cycle != snapshot.Cycle {
-			t.Errorf("Snap Shot %v, does not match the snapshot queryied: %v", c.out, snapshot)
-		}
+	snapshot, err := gt.SnapShot.Get(1)
+	if err != nil {
+		t.Error(err)
+	}
+	if snapshot.AssociatedHash == "" {
+		t.Errorf("The Snap Shot respective to cycle 1, does not match the snapshot queryied: %v", snapshot)
 	}
 }
 
 func TestBlockGetHead(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network: %v", err)
 	}
@@ -172,7 +162,7 @@ func TestBlockGetHead(t *testing.T) {
 }
 
 func TestNetworkGetConstants(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
@@ -184,7 +174,7 @@ func TestNetworkGetConstants(t *testing.T) {
 }
 
 func TestGetNetworkVersions(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
@@ -196,84 +186,100 @@ func TestGetNetworkVersions(t *testing.T) {
 }
 
 func TestGetBlockOperationHashesHead(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Operation.GetBlockOperationHashes(100000)
+	_, err = gt.Operation.GetBlockOperationHashes(7)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
 }
 
 func TestGetBlockOperationHashes(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	ops, err := gt.Operation.GetBlockOperationHashes("BMWQkPagYkqzT5sj7tjuBwwDgJRLfKBLBbdhVqqJhmgwiRgQBuk")
+	_, err = gt.Operation.GetBlockOperationHashes("head")
 	if err != nil {
 		t.Errorf("%s", err)
-	}
-
-	if len(ops) != 10 {
-		t.Errorf("%d", len(ops))
 	}
 
 }
 
 func TestGetAccountBalanceAtSnapshot(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Account.GetBalanceAtSnapshot("tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB", 15)
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	_, err = gt.Account.GetBalanceAtSnapshot(block.Metadata.Baker, 15)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
 }
 
 func TestGetAccountBalanceAtAssociatedSnapshotBlock(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Account.GetBalanceAtAssociatedSnapshotBlock("tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB", "head")
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	_, err = gt.Account.GetBalanceAtAssociatedSnapshotBlock(block.Metadata.Baker, "head")
 	if err != nil {
 		t.Errorf("%s", err)
 	}
 }
 
 func TestGetAccountBalance(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Account.GetBalance("tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB")
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	_, err = gt.Account.GetBalance(block.Metadata.Baker)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
 }
 
 func TestDelegateGetStakingBalance(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Delegate.GetStakingBalance("tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB", 15)
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	_, err = gt.Delegate.GetStakingBalance(block.Metadata.Baker, block.Metadata.Level.Cycle)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
 }
 
 func TestCycleGetCurrent(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
@@ -285,36 +291,51 @@ func TestCycleGetCurrent(t *testing.T) {
 }
 
 func TestAccountGetBalanceAtBlock(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Account.GetBalanceAtBlock("tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB", 100000)
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	_, err = gt.Account.GetBalanceAtBlock(block.Metadata.Baker, block.Header.Level)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
 }
 
 func TestDelegateGetDelegations(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Delegate.GetDelegations("tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB")
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	_, err = gt.Delegate.GetDelegations(block.Metadata.Baker)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
 }
 
 func TestGetDelegationsAtCycle(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Delegate.GetDelegationsAtCycle("tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB", 12)
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	_, err = gt.Delegate.GetDelegationsAtCycle(block.Metadata.Baker, block.Metadata.Level.Cycle-1)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
@@ -322,27 +343,36 @@ func TestGetDelegationsAtCycle(t *testing.T) {
 }
 
 func TestDelegateGetReport(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	report, err := gt.Delegate.GetReport("tz1T8UYSbVuRm6CdhjvwCfXsKXb4yL9ai9Q3", 172, 0.05)
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	report, err := gt.Delegate.GetReport(block.Metadata.Baker, block.Metadata.Level.Cycle-1, 0.05)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
 
 	t.Log(PrettyReport(report))
-
 }
 
 func TestGetPayments(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	report, err := gt.Delegate.GetReport("tz1T8UYSbVuRm6CdhjvwCfXsKXb4yL9ai9Q3", 172, 0.05)
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	report, err := gt.Delegate.GetReport(block.Metadata.Baker, block.Metadata.Level.Cycle-1, 0.05)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
@@ -352,12 +382,17 @@ func TestGetPayments(t *testing.T) {
 }
 
 func TestGetCycleRewards(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Delegate.GetRewards("tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB", 60)
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	_, err = gt.Delegate.GetRewards(block.Metadata.Baker, block.Metadata.Level.Cycle-1)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
@@ -365,12 +400,17 @@ func TestGetCycleRewards(t *testing.T) {
 }
 
 func TestGetDelegate(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Delegate.GetDelegate("tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB")
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	_, err = gt.Delegate.GetDelegate(block.Metadata.Baker)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
@@ -378,7 +418,7 @@ func TestGetDelegate(t *testing.T) {
 }
 
 func TestGetBakingRights(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
@@ -391,7 +431,7 @@ func TestGetBakingRights(t *testing.T) {
 }
 
 func TestGetBakingRightsForDelegate(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
@@ -404,12 +444,12 @@ func TestGetBakingRightsForDelegate(t *testing.T) {
 }
 
 func TestGetEndorsingRightsForDelegate(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Delegate.GetEndorsingRightsForDelegate(60, "tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB")
+	_, err = gt.Delegate.GetEndorsingRightsForDelegate(7, "tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB")
 	if err != nil {
 		t.Errorf("%s", err)
 	}
@@ -417,31 +457,36 @@ func TestGetEndorsingRightsForDelegate(t *testing.T) {
 }
 
 func TestGetEndorsingRights(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Delegate.GetEndorsingRights(60)
+	_, err = gt.Delegate.GetEndorsingRights(7)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
 }
 
 func TestGetAllDelegatesByHash(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
 
-	_, err = gt.Delegate.GetAllDelegatesByHash("BMWQkPagYkqzT5sj7tjuBwwDgJRLfKBLBbdhVqqJhmgwiRgQBuk")
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	_, err = gt.Delegate.GetAllDelegatesByHash(block.Hash)
 	if err != nil {
 		t.Errorf("%s", err)
 	}
 }
 
 func TestGetAllDelegates(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
@@ -454,7 +499,7 @@ func TestGetAllDelegates(t *testing.T) {
 }
 
 func TestBootrapped(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
@@ -467,7 +512,7 @@ func TestBootrapped(t *testing.T) {
 }
 
 func TestCommitHash(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos()
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}
@@ -480,7 +525,7 @@ func TestCommitHash(t *testing.T) {
 }
 
 func TestConnections(t *testing.T) {
-	gt, err := NewGoTezos("http://127.0.0.1:8732")
+	gt, err := NewGoTezos("")
 	if err != nil {
 		t.Errorf("could not connect to network")
 	}

--- a/gotezos_test.go
+++ b/gotezos_test.go
@@ -361,6 +361,40 @@ func TestDelegateGetReport(t *testing.T) {
 	t.Log(PrettyReport(report))
 }
 
+func TestCreateBatchPayment(t *testing.T) {
+	gt, err := NewGoTezos()
+	if err != nil {
+		t.Errorf("could not connect to network")
+	}
+
+	block, err := gt.Block.GetHead()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	report, err := gt.Delegate.GetReport(block.Metadata.Baker, block.Metadata.Level.Cycle-1, 0.05)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	payments := report.GetPayments(12700)
+
+	wallet, err := gt.Account.CreateWallet(
+		"normal dash crumble neutral reflect parrot know stairs culture fault check whale flock dog scout",
+		"vksbjweo.qsrgfvbw@tezos.example.orgPYh8nXDQLB",
+	)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	signatures, err := gt.Operation.CreateBatchPayment(payments, wallet, 1420, 10600, 1)
+
+	if len(signatures) != len(payments) {
+		t.Errorf("The batch payment result is incorrect, got %d batches instead of %d.", len(signatures), len(payments))
+	}
+
+}
+
 func TestGetPayments(t *testing.T) {
 	gt, err := NewGoTezos()
 	if err != nil {

--- a/vendor/github.com/joho/godotenv/.gitignore
+++ b/vendor/github.com/joho/godotenv/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/vendor/github.com/joho/godotenv/.travis.yml
+++ b/vendor/github.com/joho/godotenv/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - 1.x
+
+os:
+  - linux
+  - osx

--- a/vendor/github.com/joho/godotenv/LICENCE
+++ b/vendor/github.com/joho/godotenv/LICENCE
@@ -1,0 +1,23 @@
+Copyright (c) 2013 John Barton
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/vendor/github.com/joho/godotenv/README.md
+++ b/vendor/github.com/joho/godotenv/README.md
@@ -1,0 +1,163 @@
+# GoDotEnv [![Build Status](https://travis-ci.org/joho/godotenv.svg?branch=master)](https://travis-ci.org/joho/godotenv) [![Build status](https://ci.appveyor.com/api/projects/status/9v40vnfvvgde64u4?svg=true)](https://ci.appveyor.com/project/joho/godotenv) [![Go Report Card](https://goreportcard.com/badge/github.com/joho/godotenv)](https://goreportcard.com/report/github.com/joho/godotenv)
+
+A Go (golang) port of the Ruby dotenv project (which loads env vars from a .env file)
+
+From the original Library:
+
+> Storing configuration in the environment is one of the tenets of a twelve-factor app. Anything that is likely to change between deployment environments–such as resource handles for databases or credentials for external services–should be extracted from the code into environment variables.
+>
+> But it is not always practical to set environment variables on development machines or continuous integration servers where multiple projects are run. Dotenv load variables from a .env file into ENV when the environment is bootstrapped.
+
+It can be used as a library (for loading in env for your own daemons etc) or as a bin command.
+
+There is test coverage and CI for both linuxish and windows environments, but I make no guarantees about the bin version working on windows.
+
+## Installation
+
+As a library
+
+```shell
+go get github.com/joho/godotenv
+```
+
+or if you want to use it as a bin command
+```shell
+go get github.com/joho/godotenv/cmd/godotenv
+```
+
+## Usage
+
+Add your application configuration to your `.env` file in the root of your project:
+
+```shell
+S3_BUCKET=YOURS3BUCKET
+SECRET_KEY=YOURSECRETKEYGOESHERE
+```
+
+Then in your Go app you can do something like
+
+```go
+package main
+
+import (
+    "github.com/joho/godotenv"
+    "log"
+    "os"
+)
+
+func main() {
+  err := godotenv.Load()
+  if err != nil {
+    log.Fatal("Error loading .env file")
+  }
+
+  s3Bucket := os.Getenv("S3_BUCKET")
+  secretKey := os.Getenv("SECRET_KEY")
+
+  // now do something with s3 or whatever
+}
+```
+
+If you're even lazier than that, you can just take advantage of the autoload package which will read in `.env` on import
+
+```go
+import _ "github.com/joho/godotenv/autoload"
+```
+
+While `.env` in the project root is the default, you don't have to be constrained, both examples below are 100% legit
+
+```go
+_ = godotenv.Load("somerandomfile")
+_ = godotenv.Load("filenumberone.env", "filenumbertwo.env")
+```
+
+If you want to be really fancy with your env file you can do comments and exports (below is a valid env file)
+
+```shell
+# I am a comment and that is OK
+SOME_VAR=someval
+FOO=BAR # comments at line end are OK too
+export BAR=BAZ
+```
+
+Or finally you can do YAML(ish) style
+
+```yaml
+FOO: bar
+BAR: baz
+```
+
+as a final aside, if you don't want godotenv munging your env you can just get a map back instead
+
+```go
+var myEnv map[string]string
+myEnv, err := godotenv.Read()
+
+s3Bucket := myEnv["S3_BUCKET"]
+```
+
+... or from an `io.Reader` instead of a local file
+
+```go
+reader := getRemoteFile()
+myEnv, err := godotenv.Parse(reader)
+```
+
+... or from a `string` if you so desire
+
+```go
+content := getRemoteFileContent()
+myEnv, err := godotenv.Unmarshal(content)
+```
+
+### Command Mode
+
+Assuming you've installed the command as above and you've got `$GOPATH/bin` in your `$PATH`
+
+```
+godotenv -f /some/path/to/.env some_command with some args
+```
+
+If you don't specify `-f` it will fall back on the default of loading `.env` in `PWD`
+
+### Writing Env Files
+
+Godotenv can also write a map representing the environment to a correctly-formatted and escaped file
+
+```go
+env, err := godotenv.Unmarshal("KEY=value")
+err := godotenv.Write(env, "./.env")
+```
+
+... or to a string
+
+```go
+env, err := godotenv.Unmarshal("KEY=value")
+content, err := godotenv.Marshal(env)
+```
+
+## Contributing
+
+Contributions are most welcome! The parser itself is pretty stupidly naive and I wouldn't be surprised if it breaks with edge cases.
+
+*code changes without tests will not be accepted*
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Added some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+## Releases
+
+Releases should follow [Semver](http://semver.org/) though the first couple of releases are `v1` and `v1.1`.
+
+Use [annotated tags for all releases](https://github.com/joho/godotenv/issues/30). Example `git tag -a v1.2.1`
+
+## CI
+
+Linux: [![Build Status](https://travis-ci.org/joho/godotenv.svg?branch=master)](https://travis-ci.org/joho/godotenv) Windows: [![Build status](https://ci.appveyor.com/api/projects/status/9v40vnfvvgde64u4)](https://ci.appveyor.com/project/joho/godotenv)
+
+## Who?
+
+The original library [dotenv](https://github.com/bkeepers/dotenv) was written by [Brandon Keepers](http://opensoul.org/), and this port was done by [John Barton](https://johnbarton.co/) based off the tests/fixtures in the original library.

--- a/vendor/github.com/joho/godotenv/godotenv.go
+++ b/vendor/github.com/joho/godotenv/godotenv.go
@@ -1,0 +1,346 @@
+// Package godotenv is a go port of the ruby dotenv library (https://github.com/bkeepers/dotenv)
+//
+// Examples/readme can be found on the github page at https://github.com/joho/godotenv
+//
+// The TL;DR is that you make a .env file that looks something like
+//
+// 		SOME_ENV_VAR=somevalue
+//
+// and then in your go code you can call
+//
+// 		godotenv.Load()
+//
+// and all the env vars declared in .env will be available through os.Getenv("SOME_ENV_VAR")
+package godotenv
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const doubleQuoteSpecialChars = "\\\n\r\"!$`"
+
+// Load will read your env file(s) and load them into ENV for this process.
+//
+// Call this function as close as possible to the start of your program (ideally in main)
+//
+// If you call Load without any args it will default to loading .env in the current path
+//
+// You can otherwise tell it which files to load (there can be more than one) like
+//
+//		godotenv.Load("fileone", "filetwo")
+//
+// It's important to note that it WILL NOT OVERRIDE an env variable that already exists - consider the .env file to set dev vars or sensible defaults
+func Load(filenames ...string) (err error) {
+	filenames = filenamesOrDefault(filenames)
+
+	for _, filename := range filenames {
+		err = loadFile(filename, false)
+		if err != nil {
+			return // return early on a spazout
+		}
+	}
+	return
+}
+
+// Overload will read your env file(s) and load them into ENV for this process.
+//
+// Call this function as close as possible to the start of your program (ideally in main)
+//
+// If you call Overload without any args it will default to loading .env in the current path
+//
+// You can otherwise tell it which files to load (there can be more than one) like
+//
+//		godotenv.Overload("fileone", "filetwo")
+//
+// It's important to note this WILL OVERRIDE an env variable that already exists - consider the .env file to forcefilly set all vars.
+func Overload(filenames ...string) (err error) {
+	filenames = filenamesOrDefault(filenames)
+
+	for _, filename := range filenames {
+		err = loadFile(filename, true)
+		if err != nil {
+			return // return early on a spazout
+		}
+	}
+	return
+}
+
+// Read all env (with same file loading semantics as Load) but return values as
+// a map rather than automatically writing values into env
+func Read(filenames ...string) (envMap map[string]string, err error) {
+	filenames = filenamesOrDefault(filenames)
+	envMap = make(map[string]string)
+
+	for _, filename := range filenames {
+		individualEnvMap, individualErr := readFile(filename)
+
+		if individualErr != nil {
+			err = individualErr
+			return // return early on a spazout
+		}
+
+		for key, value := range individualEnvMap {
+			envMap[key] = value
+		}
+	}
+
+	return
+}
+
+// Parse reads an env file from io.Reader, returning a map of keys and values.
+func Parse(r io.Reader) (envMap map[string]string, err error) {
+	envMap = make(map[string]string)
+
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err = scanner.Err(); err != nil {
+		return
+	}
+
+	for _, fullLine := range lines {
+		if !isIgnoredLine(fullLine) {
+			var key, value string
+			key, value, err = parseLine(fullLine, envMap)
+
+			if err != nil {
+				return
+			}
+			envMap[key] = value
+		}
+	}
+	return
+}
+
+//Unmarshal reads an env file from a string, returning a map of keys and values.
+func Unmarshal(str string) (envMap map[string]string, err error) {
+	return Parse(strings.NewReader(str))
+}
+
+// Exec loads env vars from the specified filenames (empty map falls back to default)
+// then executes the cmd specified.
+//
+// Simply hooks up os.Stdin/err/out to the command and calls Run()
+//
+// If you want more fine grained control over your command it's recommended
+// that you use `Load()` or `Read()` and the `os/exec` package yourself.
+func Exec(filenames []string, cmd string, cmdArgs []string) error {
+	Load(filenames...)
+
+	command := exec.Command(cmd, cmdArgs...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}
+
+// Write serializes the given environment and writes it to a file
+func Write(envMap map[string]string, filename string) error {
+	content, error := Marshal(envMap)
+	if error != nil {
+		return error
+	}
+	file, error := os.Create(filename)
+	if error != nil {
+		return error
+	}
+	_, err := file.WriteString(content)
+	return err
+}
+
+// Marshal outputs the given environment as a dotenv-formatted environment file.
+// Each line is in the format: KEY="VALUE" where VALUE is backslash-escaped.
+func Marshal(envMap map[string]string) (string, error) {
+	lines := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		lines = append(lines, fmt.Sprintf(`%s="%s"`, k, doubleQuoteEscape(v)))
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n"), nil
+}
+
+func filenamesOrDefault(filenames []string) []string {
+	if len(filenames) == 0 {
+		return []string{".env"}
+	}
+	return filenames
+}
+
+func loadFile(filename string, overload bool) error {
+	envMap, err := readFile(filename)
+	if err != nil {
+		return err
+	}
+
+	currentEnv := map[string]bool{}
+	rawEnv := os.Environ()
+	for _, rawEnvLine := range rawEnv {
+		key := strings.Split(rawEnvLine, "=")[0]
+		currentEnv[key] = true
+	}
+
+	for key, value := range envMap {
+		if !currentEnv[key] || overload {
+			os.Setenv(key, value)
+		}
+	}
+
+	return nil
+}
+
+func readFile(filename string) (envMap map[string]string, err error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	return Parse(file)
+}
+
+func parseLine(line string, envMap map[string]string) (key string, value string, err error) {
+	if len(line) == 0 {
+		err = errors.New("zero length string")
+		return
+	}
+
+	// ditch the comments (but keep quoted hashes)
+	if strings.Contains(line, "#") {
+		segmentsBetweenHashes := strings.Split(line, "#")
+		quotesAreOpen := false
+		var segmentsToKeep []string
+		for _, segment := range segmentsBetweenHashes {
+			if strings.Count(segment, "\"") == 1 || strings.Count(segment, "'") == 1 {
+				if quotesAreOpen {
+					quotesAreOpen = false
+					segmentsToKeep = append(segmentsToKeep, segment)
+				} else {
+					quotesAreOpen = true
+				}
+			}
+
+			if len(segmentsToKeep) == 0 || quotesAreOpen {
+				segmentsToKeep = append(segmentsToKeep, segment)
+			}
+		}
+
+		line = strings.Join(segmentsToKeep, "#")
+	}
+
+	firstEquals := strings.Index(line, "=")
+	firstColon := strings.Index(line, ":")
+	splitString := strings.SplitN(line, "=", 2)
+	if firstColon != -1 && (firstColon < firstEquals || firstEquals == -1) {
+		//this is a yaml-style line
+		splitString = strings.SplitN(line, ":", 2)
+	}
+
+	if len(splitString) != 2 {
+		err = errors.New("Can't separate key from value")
+		return
+	}
+
+	// Parse the key
+	key = splitString[0]
+	if strings.HasPrefix(key, "export") {
+		key = strings.TrimPrefix(key, "export")
+	}
+	key = strings.Trim(key, " ")
+
+	// Parse the value
+	value = parseValue(splitString[1], envMap)
+	return
+}
+
+func parseValue(value string, envMap map[string]string) string {
+
+	// trim
+	value = strings.Trim(value, " ")
+
+	// check if we've got quoted values or possible escapes
+	if len(value) > 1 {
+		rs := regexp.MustCompile(`\A'(.*)'\z`)
+		singleQuotes := rs.FindStringSubmatch(value)
+
+		rd := regexp.MustCompile(`\A"(.*)"\z`)
+		doubleQuotes := rd.FindStringSubmatch(value)
+
+		if singleQuotes != nil || doubleQuotes != nil {
+			// pull the quotes off the edges
+			value = value[1 : len(value)-1]
+		}
+
+		if doubleQuotes != nil {
+			// expand newlines
+			escapeRegex := regexp.MustCompile(`\\.`)
+			value = escapeRegex.ReplaceAllStringFunc(value, func(match string) string {
+				c := strings.TrimPrefix(match, `\`)
+				switch c {
+				case "n":
+					return "\n"
+				case "r":
+					return "\r"
+				default:
+					return match
+				}
+			})
+			// unescape characters
+			e := regexp.MustCompile(`\\([^$])`)
+			value = e.ReplaceAllString(value, "$1")
+		}
+
+		if singleQuotes == nil {
+			value = expandVariables(value, envMap)
+		}
+	}
+
+	return value
+}
+
+func expandVariables(v string, m map[string]string) string {
+	r := regexp.MustCompile(`(\\)?(\$)(\()?\{?([A-Z0-9_]+)?\}?`)
+
+	return r.ReplaceAllStringFunc(v, func(s string) string {
+		submatch := r.FindStringSubmatch(s)
+
+		if submatch == nil {
+			return s
+		}
+		if submatch[1] == "\\" || submatch[2] == "(" {
+			return submatch[0][1:]
+		} else if submatch[4] != "" {
+			return m[submatch[4]]
+		}
+		return s
+	})
+}
+
+func isIgnoredLine(line string) bool {
+	trimmedLine := strings.Trim(line, " \n\t")
+	return len(trimmedLine) == 0 || strings.HasPrefix(trimmedLine, "#")
+}
+
+func doubleQuoteEscape(line string) string {
+	for _, c := range doubleQuoteSpecialChars {
+		toReplace := "\\" + string(c)
+		if c == '\n' {
+			toReplace = `\n`
+		}
+		if c == '\r' {
+			toReplace = `\r`
+		}
+		line = strings.Replace(line, string(c), toReplace, -1)
+	}
+	return line
+}

--- a/vendor/github.com/pkg/errors/.gitignore
+++ b/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.x
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - tip
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors) [![Sourcegraph](https://sourcegraph.com/github.com/pkg/errors/-/badge.svg)](https://sourcegraph.com/github.com/pkg/errors?badge)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## License
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,282 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which when applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// together with the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required, the errors.WithStack and
+// errors.WithMessage functions destructure errors.Wrap into its component
+// operations: annotating an error with a stack trace and with a message,
+// respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error that does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Although the causer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported:
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively.
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface:
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// The returned errors.StackTrace type is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// Although the stackTracer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is called, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+// WithMessagef annotates err with the format specifier.
+// If err is nil, WithMessagef returns nil.
+func WithMessagef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,147 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,9 @@
 # github.com/Messer4/base58check v0.0.0-20180328134002-7531a92ae9ba
 github.com/Messer4/base58check
+# github.com/joho/godotenv v1.3.0
+github.com/joho/godotenv
+# github.com/pkg/errors v0.8.1
+github.com/pkg/errors
 # golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 golang.org/x/crypto/blake2b
 golang.org/x/crypto/ed25519


### PR DESCRIPTION
Added support for environment variables that can be stored inside `.env` file, this removes the hard coded rpc address inside `gotezos_test.go` and makes tests easier to use with custom rpc addresses. Now NewGoTezos() constructor is a `variadic function` that can be empty, in this case it will load the 'RPC_ADDRESS' from `.env` file.

Added a test to `CreateBatchPayment` that verifies the new `batch size` changes and abstracted some tests for them to work with any network, `mainnet`, `alphanet` and `zeronet`.

Also is now possible to set a custom `batch size` as requested in #62 and the max batch size allowed is now 200 transactions per operation.