### PR TITLE
[WIP] operations: adding a safe forge function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/DefinitelyNotAGoat/go-tezos/v2
 
 go 1.13
+
+require (
+	github.com/google/go-cmp v0.3.1 // indirect
+	github.com/pkg/errors v0.8.1
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	gotest.tools v2.2.0+incompatible
+)


### PR DESCRIPTION
The current forging of operations used a tezos node to forge.
This is a security risk because you have to trust the node to forge
the correct operation. ForgeOperation() solves this by forging the
operation with Go and not an external node.